### PR TITLE
Jiras 43798, 43684, 43672, 43670

### DIFF
--- a/input/intro-notes/StructureDefinition-diagnostic-implication-intro.xml
+++ b/input/intro-notes/StructureDefinition-diagnostic-implication-intro.xml
@@ -3,6 +3,23 @@
     This section provides guidance for genomic reporting of patient genetic implications regarding specific conditions (sometimes referred to as phenotypes). This portion of the implementation guide relies on the content in the <a href="general.html">General Genomic Reporting</a> and <a href="sequencing.html">Variant Reporting</a> portions of this implementation guide. 
   </p>
 
+<a name="usageNotes"> </a>
+	<h3>General usage notes</h3>
+<p>The diagnostic implication profile can be used to annotate variants, haplotypes, genotypes, or molecular biomarkers 
+with phenotype associations. For example, this profile can be used to assert that the presence of a variant is associated with an 
+increased risk of breast cancer. </p>
+<p>Useful components include:</p>
+<ul>
+<li><b>component:conclusion-string</b>: Concise and clinically contextualized summary conclusion (interpretation/impression) of the observation</li>
+<li><b>component:evidence-level</b>: The amount of observed support for the association between an implication and a variant / haplotype / genotype / biomarker. (See the discussion of <a href="StructureDefinition-implication.html#Evidence-Significance">evidence-level vs. clinical significance</a> for additional guidance.)</li>
+<li><b>component:clinical-significance</b>: The clinical impact of an implication on a person's health. (See the discussion of <a href="StructureDefinition-implication.html#Evidence-Significance">evidence-level vs. clinical significance</a> for additional guidance.) </li>
+<li><b>component:predicted-phenotype</b>: An observable characteristic (e.g., condition, disease, physical finding) of an individual</li>
+<li><b>component:mode-of-inheritance</b>: The transmission pattern of the condition/phenotype in a pedigree.</li>
+</ul>
+<p>As with all implications, the explicit reference to the variant(s)/haplotype(s)/genotype(s)/molecular biomarker(s) being 
+annotated must be provided in the Observation.derivedFrom field.</p>
+
+
 <a name="Evidence-Significance"> </a>
 	<h3>evidence-level versus clinical-significance</h3>
 	<p>

--- a/input/intro-notes/StructureDefinition-implication-intro.xml
+++ b/input/intro-notes/StructureDefinition-implication-intro.xml
@@ -5,10 +5,20 @@
 	This portion of the implementation guide relies on the content in the <a href="general.html">General Genomic Reporting</a> and <a href="sequencing.html">Variant Reporting</a> portions of this implementation guide.  
   </p>
 
+<p>At the heart of many genomic reports are findings (<a href="StructureDefinition-variant.html">variants</a>, 
+<a href="StructureDefinition-haplotype.html">haplotypes</a>, 
+<a href="StructureDefinition-genotype.html">genotypes</a>, 
+<a href="StructureDefinition-molecular-biomarker.html">biomarkers</a>) and annotations derived from those findings (<a href="StructureDefinition-diagnostic-implication.html">diagnostic implications</a>, 
+<a href="StructureDefinition-therapeutic-implication.html">therapeutic implications</a>, 
+<a href="StructureDefinition-molecular-consequence.html">predicted molecular consequences</a>), as shown in the following figure:</p>
+<img src="Somatic_General_Guidance.svg" alt="generalGuidance" height="195" width="410"/>
+<p> </p>
+
  <p>
     This profile defines a common set of elements for other Implications:
  </p>
   <ul>
+  	<li><code>derivedFrom</code> is a required field that provides an explicit reference from an implication to the variant(s) / haplotype(s) / genotype(s) / molecular biomarker(s) from which the implication is derived.</li>
     <li><code>workflow-relatedArtifact (base extension)</code> supports conveying references to citations, supporting documentation and other information relevant to the asserted implication, such as documentation which applies to the full implication Observation</li>
     <li><code>workflow-relatedArtifactComponent (component level extension)</code> supports conveying references to citations, supporting documentation and other information specific to the component's code and value, such as documentation supporting a specific clinical significance or evidence level value</li>    
 		<li><code>evidence-level (component)</code> indicates the strength of the evidence behind the asserted implication</li>
@@ -99,7 +109,7 @@
 		This situation is not unique to genomic implications, and arises elsewhere within FHIR (e.g. <a href="https://www.hl7.org/fhir/search.html#combining">FHIR Search</a>) and outside of FHIR (e.g., <a href="https://www.ncbi.nlm.nih.gov/clinvar/docs/api_http/">ClinVar submission API</a> condition set). To be consistent with other precedents:
   </p>
   <p>
-		Where Diagnostic and Therapeutic implications have fields with cardinality > 1, the inclusion of multiple values within a field SHALL indicate an 'AND' condition. An 'OR' condition SHALL be represented by multiple observation instances.
+		Where implications have fields with cardinality > 1, the inclusion of multiple values within a field SHALL indicate an 'AND' condition. An 'OR' condition SHALL be represented by multiple observation instances.
 	</p>
 	<p>
 		Implication fields affected by this guidance include:

--- a/input/pages/usecases.xml
+++ b/input/pages/usecases.xml
@@ -78,7 +78,7 @@
     *Return a bundle of genetics Observation instances
   </p>
   <a name="cancerProfiling"></a>
-  <h4>Cancer Profiling</h4>
+  <h4>Get references to somatic variants on a specific date</h4>
   <p>
     The goal of this profile methodology is to get references from all variants obtained from
     somatic analysis that were identified as having somatic origin. Changes in the population of


### PR DESCRIPTION
Implements these STU3 ballot resolutions: 

- [FHIR-43798](https://jira.hl7.org/browse/FHIR-43798) Cancer Profiling Query Guidance does not provide accurate or sufficient context.
- [FHIR-43684](https://jira.hl7.org/browse/FHIR-43672) Need more intro guidance for DiagnosticImplication
- [FHIR-43672](https://jira.hl7.org/browse/FHIR-43672) Intro guidance should include mention of 'derivedFrom'
- [FHIR-43670](https://jira.hl7.org/browse/FHIR-43672) Addition of Molecular Consequence should trigger a few more changes to Genomic Implication guidance

Changes can be seen here: https://build.fhir.org/ig/HL7/genomics-reporting/branches/stu3-ballot-resolutions/